### PR TITLE
fix regular expressions to escape characters, digits, underscore and dashes

### DIFF
--- a/telegram.go
+++ b/telegram.go
@@ -32,9 +32,9 @@ const (
 	telegramApiSendMessage string = "/sendMessage"
 	telegramTokenEnv       string = "GITHUB_BOT_TOKEN"
 	defaulRepoLen          int    = 4
-	repoExpr               string = `^\/search\s(\w*)\s*.*`
+	repoExpr               string = `^\/search\s(([A-Za-z0-9\-\_]+))\s*.*`
 	langExpr               string = `^\/search\s.*\s+lang:([\w]*)`
-	authorExpr             string = `^\/search\s.*\s+author:([\w]*)`
+	authorExpr             string = `^\/search\s.*\s+author:(([A-Za-z0-9\-\_]+))`
 	langParam              string = "lang"
 	authorParam            string = "author"
 )

--- a/telegram_test.go
+++ b/telegram_test.go
@@ -73,6 +73,17 @@ func TestExtractParams(t *testing.T) {
 				lang:   "go",
 			},
 		},
+		{
+			name: "providing an repo and author with dashes in the name",
+			input: input{
+				s: "/search go-swagger author:go-swagger lang:go",
+			},
+			expected: expected{
+				repo:   "go-swagger",
+				author: "go-swagger",
+				lang:   "go",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fix regular expressions to escape dashes:

repo: `^\/search\s(([A-Za-z0-9\-\_]+))\s*.*`
author: `^\/search\s.*\s+author:(([A-Za-z0-9\-\_]+))` 